### PR TITLE
Add necessary imports in main.go example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ This is the API I have defined:
 package main
 
 import (
-    "testing",
-    "github.com/gianarb/testcontainer"
+	"context"
+	"fmt"
+	testcontainer "github.com/gianarb/testcontainer-go"
+	"net/http"
+	"testing"
 )
 
 func TestNginxLatestReturn(t *testing.T) {


### PR DESCRIPTION
The previous example didn't compile, so I added the missing imports and renamed the one referring to `github.com/gianarb/testcontainers`.

Signed-off-by: Sune Keller <sune.keller@gmail.com>